### PR TITLE
Simplify arrays operations formatting

### DIFF
--- a/lib/src/decompiler/function.rs
+++ b/lib/src/decompiler/function.rs
@@ -9,8 +9,9 @@ use cairo_lang_sierra::program::StatementIdx;
 use crate::decompiler::cfg::ControlFlowGraph;
 use crate::decompiler::cfg::SierraConditionalBranch;
 use crate::decompiler::libfuncs_patterns::{
-    ADDITION_REGEX, CONST_REGEXES, DROP_REGEX, DUP_REGEX, FUNCTION_CALL_REGEX,
-    MULTIPLICATION_REGEX, STORE_TEMP_REGEX, SUBSTRACTION_REGEX, VARIABLE_ASSIGNMENT_REGEX,
+    ADDITION_REGEX, ARRAY_APPEND_REGEX, CONST_REGEXES, DROP_REGEX, DUP_REGEX, FUNCTION_CALL_REGEX,
+    MULTIPLICATION_REGEX, NEW_ARRAY_REGEX, STORE_TEMP_REGEX, SUBSTRACTION_REGEX,
+    VARIABLE_ASSIGNMENT_REGEX,
 };
 use crate::decompiler::utils::decode_hex_bigint;
 use crate::extract_parameters;
@@ -185,6 +186,35 @@ impl SierraStatement {
                 let assigned_variable = assigned_variables_str.to_string();
                 return format!("{} = {}", assigned_variable, old_var);
             }
+        }
+
+        // Handling array declarations
+        // <variable> = Array<<array type>>::new()
+        if let Some(captures) = NEW_ARRAY_REGEX.captures(libfunc_id_str) {
+            if let Some(array_type) = captures.get(1) {
+                let formatted_array_type = array_type.as_str();
+                return format!(
+                    "{} = {}<{}>::{}()",
+                    assigned_variables_str,
+                    "Array".blue(),
+                    formatted_array_type,
+                    "new".blue()
+                );
+            }
+        }
+
+        // Handling array append operations
+        // <variable> = <array>.append(<variable>)
+        if ARRAY_APPEND_REGEX.is_match(libfunc_id_str) {
+            let array_name = parameters[0].clone();
+            let appent_value_name = parameters[1].clone();
+            return format!(
+                "{} = {}.{}({})",
+                assigned_variables_str,
+                array_name,
+                "append".blue(),
+                appent_value_name
+            );
         }
 
         // Handling const declarations

--- a/lib/src/decompiler/libfuncs_patterns.rs
+++ b/lib/src/decompiler/libfuncs_patterns.rs
@@ -41,4 +41,8 @@ lazy_static! {
         Regex::new(r"storage_base_address_const<(?P<const>-?[0-9]+)>").unwrap(),
         Regex::new(r"(felt|u)_?(8|16|32|64|128|252)_const<(?P<const>-?[0-9]+)>").unwrap(),
     ];
+
+    // Array declarations & mutations
+    pub static ref NEW_ARRAY_REGEX: Regex = Regex::new(r"array_new<(?P<array_type>.+)>").unwrap();
+    pub static ref ARRAY_APPEND_REGEX: Regex = Regex::new(r"array_append<(.+)>").unwrap();
 }

--- a/lib/tests/test_decompiler.rs
+++ b/lib/tests/test_decompiler.rs
@@ -95,3 +95,50 @@ func examples::fib::fib (v0: felt252, v1: felt252, v2: felt252) -> (felt252) {
 }"#;
     assert_eq!(decompiler_output, expected_output);
 }
+
+#[test]
+fn test_decompiler_array_output() {
+    // Read file content
+    let content = include_str!("../../examples/sierra/fib_gas.sierra").to_string();
+
+    // Init a new SierraProgram with the .sierra file content
+    let program = SierraProgram::new(content);
+
+    // Don't Use the verbose output
+    let verbose_output = false;
+
+    // Decompile the Sierra program
+    let mut decompiler = program.decompiler(verbose_output);
+
+    // Decompile the sierra program with a colorless output
+    let use_color = false;
+    let decompiler_output = decompiler.decompile(use_color);
+
+    let expected_output = r#"// Function 1
+func examples::fib::fib (v0: RangeCheck, v1: GasBuiltin, v2: felt252, v3: felt252, v4: felt252) -> (RangeCheck, GasBuiltin, core::panics::PanicResult::<(core::felt252)>) {
+	if (withdraw_gas(v0, v1) == 0) {		
+		v20 = Array<felt252>::new()
+		v21 = 375233589013918064796019 // "Out of gas"
+		v22 = v20.append(v21)
+		v23 = struct_construct<core::panics::Panic>()
+		v24 = struct_construct<Tuple<core::panics::Panic, Array<felt252>>>(v23, v22)
+		v25 = enum_init<core::panics::PanicResult::<(core::felt252)>, 1>(v24)
+		return (v7, v8, v25)
+	} else {	
+		v9 = v4
+		if (v9 == 0) {			
+			v13 = v3
+			v14 = v2 + v13
+			v15 = 1
+			v16 = v4 - v15
+			v17, v18, v19 = user@examples::fib::fib(v5, v6, v3, v14, v16)
+			return (v17, v18, v19)
+		} else {		
+			v11 = struct_construct<Tuple<felt252>>(v2)
+			v12 = enum_init<core::panics::PanicResult::<(core::felt252)>, 0>(v11)
+			return (v5, v6, v12)
+		}
+	}
+}"#;
+    assert_eq!(decompiler_output, expected_output);
+}


### PR DESCRIPTION
This PR improves the formatting of arrays creations and modifications in the decompiler output. 
- Array creation : `Array<felt252>::new()`.
- Appending a value to the array : `v1.append(v2)`.