### PR TITLE
Improve the decompiler output for remote contracts

### DIFF
--- a/lib/src/decompiler/decompiler.rs
+++ b/lib/src/decompiler/decompiler.rs
@@ -552,11 +552,13 @@ impl<'a> Decompiler<'a> {
                 // Add the formatted statements to the block
                 // Some statements are only included in the verbose output
                 //
-                // We pass it the declared libfunc names to allow the method to reconstruct function calls
-                // For remote contracts
-                if let Some(formatted_statement) = statement
-                    .formatted_statement(self.verbose, self.declared_libfuncs_names.clone())
-                {
+                // We pass it the declared libfunc names & types names to allow the method
+                // to reconstruct function calls & used types for remote contracts
+                if let Some(formatted_statement) = statement.formatted_statement(
+                    self.verbose,
+                    self.declared_libfuncs_names.clone(),
+                    self.declared_types_names.clone(),
+                ) {
                     decompiled_basic_block += &format!("{}{}\n", indentation, formatted_statement);
                 }
             }

--- a/lib/src/decompiler/decompiler.rs
+++ b/lib/src/decompiler/decompiler.rs
@@ -13,6 +13,7 @@ use crate::decompiler::cfg::EdgeType;
 use crate::decompiler::function::Function;
 use crate::decompiler::function::SierraStatement;
 use crate::decompiler::libfuncs_patterns::{IS_ZERO_REGEX, USER_DEFINED_FUNCTION_REGEX};
+use crate::decompiler::utils::replace_types_id;
 use crate::parse_element_name;
 use crate::parse_element_name_with_fallback;
 use crate::sierra_program::SierraProgram;
@@ -591,7 +592,8 @@ impl<'a> Decompiler<'a> {
         format!(
             "{}if ({}({}) == 0) {}{}\n",
             indentation_str,
-            function_name,
+            // Recover the type from type_id if it's a remote contract
+            replace_types_id(&self.declared_types_names, function_name).blue(),
             function_arguments,
             bold_brace_open,
             "\t".repeat(indentation + 1) // Adjust for nested content indentation

--- a/lib/src/decompiler/decompiler.rs
+++ b/lib/src/decompiler/decompiler.rs
@@ -31,9 +31,9 @@ pub struct Decompiler<'a> {
     /// The function we are currently working on
     current_function: Option<Function<'a>>,
     /// Names of all declared types (in order)
-    declared_types_names: Vec<String>,
+    pub declared_types_names: Vec<String>,
     /// Names of all declared libfuncs (in order)
-    declared_libfuncs_names: Vec<String>,
+    pub declared_libfuncs_names: Vec<String>,
     /// Enable / disable the verbose output
     /// Some statements are not included in the regular output to improve the readability
     verbose: bool,

--- a/lib/src/decompiler/function.rs
+++ b/lib/src/decompiler/function.rs
@@ -150,6 +150,10 @@ impl SierraStatement {
         verbose: &bool,
         declared_types_names: &Vec<String>,
     ) -> String {
+        // Replace types id in libfuncs names by their types names equivalents in remote contracts
+        let binding = replace_types_id(declared_types_names, &libfunc_id_str);
+        let libfunc_id_str = binding.as_str();
+
         // Join parameters for general use
         let parameters_str = parameters.join(", ");
 
@@ -161,17 +165,11 @@ impl SierraStatement {
                     return format!(
                         "{} = {}({})",
                         assigned_variables_str,
-                        // Recover the type from type_id if it's a remote contract
-                        replace_types_id(declared_types_names, formatted_func).blue(),
+                        formatted_func.blue(),
                         parameters_str
                     );
                 } else {
-                    return format!(
-                        "{}({})",
-                        // Recover the type from type_id if it's a remote contract
-                        replace_types_id(declared_types_names, formatted_func).blue(),
-                        parameters_str
-                    );
+                    return format!("{}({})", formatted_func.blue(), parameters_str);
                 }
             }
         }
@@ -184,8 +182,7 @@ impl SierraStatement {
                 return format!(
                     "{} = {}({})",
                     assigned_variables_str,
-                    // Recover the type from type_id if it's a remote contract
-                    replace_types_id(declared_types_names, libfunc_id_str).blue(),
+                    libfunc_id_str.blue(),
                     parameters_str
                 );
             }
@@ -217,9 +214,7 @@ impl SierraStatement {
             if let Some(array_type) = captures.get(1) {
                 let formatted_array_type = array_type.as_str();
 
-                // Attempt to get the type from declared_types_names if formatted_array_type is in the form [<number>]
-                // It is used to recover the used type for remote contracts
-                let final_array_type = replace_types_id(declared_types_names, formatted_array_type);
+                let final_array_type = formatted_array_type;
 
                 // Return the formatted array declaration string
                 return format!(
@@ -247,7 +242,6 @@ impl SierraStatement {
         }
 
         // Handling const declarations
-        // TODO : Fix the bug whit remote contracts where consts aren't decoded to strings
         for regex in CONST_REGEXES.iter() {
             if let Some(captures) = regex.captures(libfunc_id_str) {
                 if let Some(const_value) = captures.name("const") {
@@ -285,17 +279,11 @@ impl SierraStatement {
                 format!(
                     "{} = {}({})",
                     assigned_variables_str,
-                    // Recover the type from type_id if it's a remote contract
-                    replace_types_id(declared_types_names, libfunc_id_str).blue(),
+                    libfunc_id_str.blue(),
                     parameters_str
                 )
             } else {
-                format!(
-                    "{}({})",
-                    // Recover the type from type_id if it's a remote contract
-                    replace_types_id(declared_types_names, libfunc_id_str).blue(),
-                    parameters_str
-                )
+                format!("{}({})", libfunc_id_str.blue(), parameters_str)
             };
         };
 

--- a/lib/src/decompiler/function.rs
+++ b/lib/src/decompiler/function.rs
@@ -128,6 +128,7 @@ impl SierraStatement {
         match function_name {
             "branch_align"
             | "disable_ap_tracking"
+            | "enable_ap_tracking"
             | "finalize_locals"
             | "revoke_ap_tracking"
             | "get_builtin_costs" => false,

--- a/lib/src/decompiler/libfuncs_patterns.rs
+++ b/lib/src/decompiler/libfuncs_patterns.rs
@@ -29,7 +29,9 @@ lazy_static! {
     // Variable renaming
     pub static ref VARIABLE_ASSIGNMENT_REGEX: Vec<Regex> = vec![
         Regex::new(r"rename<.+>").unwrap(),
-        Regex::new(r"store_temp<.+>").unwrap()
+        Regex::new(r"store_temp<.+>").unwrap(),
+        Regex::new(r"store_local<.+>").unwrap(),
+        Regex::new(r"unbox<.+>").unwrap()
     ];
 
     // Check if an integer is 0

--- a/lib/src/decompiler/libfuncs_patterns.rs
+++ b/lib/src/decompiler/libfuncs_patterns.rs
@@ -48,4 +48,8 @@ lazy_static! {
     // Array declarations & mutations
     pub static ref NEW_ARRAY_REGEX: Regex = Regex::new(r"array_new<(?P<array_type>.+)>").unwrap();
     pub static ref ARRAY_APPEND_REGEX: Regex = Regex::new(r"array_append<(.+)>").unwrap();
+
+    // Regex of a type ID
+    // Used to match and replace them in remote contracts
+    pub static ref TYPE_ID_REGEX: Regex = Regex::new(r"(?<type_id>\[[0-9]+\])").unwrap();
 }

--- a/lib/src/decompiler/libfuncs_patterns.rs
+++ b/lib/src/decompiler/libfuncs_patterns.rs
@@ -37,7 +37,7 @@ lazy_static! {
 
     // Consts declarations
     pub static ref CONST_REGEXES: Vec<Regex> = vec![
-        Regex::new(r"const_as_immediate<Const<.+, (?P<const>-?[0-9]+)>>").unwrap(),
+        Regex::new(r"const_as_immediate<Const<.*, (?P<const>-?[0-9]+)>>").unwrap(),
         Regex::new(r"storage_base_address_const<(?P<const>-?[0-9]+)>").unwrap(),
         Regex::new(r"(felt|u)_?(8|16|32|64|128|252)_const<(?P<const>-?[0-9]+)>").unwrap(),
     ];


### PR DESCRIPTION
This PR : 
- Simplify the decompiler output for `store_local` and  `enable_ap_tracking` libfuncs calls.
- Improve the decompiler output for remote contracts by recovering the libfuncs & types names.  