### PR TITLE
Update detectors management

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,9 @@ When running the detectors we can generate test cases for each path in the funct
 
 
 ```
-cargo run -- -f ./examples/sierra/fib_array.sierra  -d
+cargo run -- -f ./examples/sierra/symbolic_execution_test.sierra -d --detector-names tests
 
-[...]
-
-[Informational] Tests generator
+[Testing] Tests generator
         - symbolic::symbolic::symbolic_execution_test : 
         - v0: 102, v1: 0, v2: 0, v3: 0
         - v0: 103, v1: 0, v2: 0, v3: 0

--- a/bin/sierra-decompiler/src/main.rs
+++ b/bin/sierra-decompiler/src/main.rs
@@ -234,10 +234,13 @@ fn handle_detectors(decompiler: &mut Decompiler, detector_names: Vec<String>) {
 
     // Run the specified detectors
     for detector in detectors.iter_mut() {
-        // Skip TESTING detectors and detectors not in the provided names
-        if detector.detector_type() == DetectorType::TESTING
-            || !detector_names.is_empty() && !detector_names.contains(&detector.id().to_string())
-        {
+        // Skip TESTING detectors if no specific detector names are provided
+        if detector_names.is_empty() && detector.detector_type() == DetectorType::TESTING {
+            continue;
+        }
+
+        // Skip detectors not in the provided names if names are provided
+        if !detector_names.is_empty() && !detector_names.contains(&detector.id().to_string()) {
             continue;
         }
 

--- a/bin/sierra-decompiler/src/main.rs
+++ b/bin/sierra-decompiler/src/main.rs
@@ -9,6 +9,7 @@ use tokio;
 
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use sierra_analyzer_lib::decompiler::decompiler::Decompiler;
+use sierra_analyzer_lib::detectors::detector::DetectorType;
 use sierra_analyzer_lib::detectors::get_detectors;
 use sierra_analyzer_lib::graph::graph::save_svg_graph_to_file;
 use sierra_analyzer_lib::provider::NetworkConfig;
@@ -227,8 +228,13 @@ fn handle_detectors(decompiler: &mut Decompiler) {
     let mut detectors = get_detectors();
     let mut output = String::new();
 
-    // Run all the detectors
+    // Run all the detectors except those of type TESTING
     for detector in detectors.iter_mut() {
+        // Skip TESTING detectors
+        if detector.detector_type() == DetectorType::TESTING {
+            continue;
+        }
+
         let result = detector.detect(decompiler);
         if !result.trim().is_empty() {
             // Each detector output is formatted like

--- a/lib/src/detectors/detector.rs
+++ b/lib/src/detectors/detector.rs
@@ -8,6 +8,7 @@ use crate::decompiler::decompiler::Decompiler;
 pub enum DetectorType {
     INFORMATIONAL,
     SECURITY,
+    TESTING,
 }
 
 impl DetectorType {
@@ -20,6 +21,9 @@ impl DetectorType {
 
             // Security detectors types are blue
             DetectorType::SECURITY => "Security".normal().blue(),
+
+            // Testing detectors types are yellow
+            DetectorType::TESTING => "Testing".normal().yellow(),
         }
     }
 }

--- a/lib/src/detectors/detector.rs
+++ b/lib/src/detectors/detector.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use crate::decompiler::decompiler::Decompiler;
 
 /// Possible types of a detector
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum DetectorType {
     INFORMATIONAL,
     SECURITY,

--- a/lib/src/detectors/functions_detector.rs
+++ b/lib/src/detectors/functions_detector.rs
@@ -54,6 +54,9 @@ impl Detector for FunctionsDetector {
                 if index < total_functions - 1 {
                     result += "\n";
                 }
+
+                // Append the ANSI reset sequence
+                result += &"\x1b[0m".to_string();
             }
         }
         result

--- a/lib/src/detectors/tests_generator_detector.rs
+++ b/lib/src/detectors/tests_generator_detector.rs
@@ -32,9 +32,10 @@ impl Detector for TestsGeneratorDetector {
     }
 
     /// Returns the type of the detector
+    /// Detectors in the TESTING category are not displayed by default using the --detector flag
     #[inline]
     fn detector_type(&self) -> DetectorType {
-        DetectorType::INFORMATIONAL
+        DetectorType::TESTING
     }
 
     /// Returns the generated unit tests for the function if they exist

--- a/lib/tests/detectors.rs
+++ b/lib/tests/detectors.rs
@@ -54,8 +54,8 @@ fn test_functions_detector() {
     // functions names
     let functions_names = detector.detect(&mut decompiler);
 
-    let expected_output = r#"examples::fib_array::fib
-examples::fib_array::fib_inner"#;
+    let expected_output =
+        "examples::fib_array::fib\n\u{1b}[0mexamples::fib_array::fib_inner\u{1b}[0m";
 
     assert_eq!(functions_names, expected_output);
 }


### PR DESCRIPTION
This PR : 
- Moves the test generator to a new `TESTING` category and don't print it by default in the detectors output.
- Creates a `--detector-names` flag to filter the used detectors. 
- Updates documentation. 